### PR TITLE
[ADD] pagination sur GET /api/job-offers

### DIFF
--- a/Back/src/main/java/ma/emsi/smartrhv1/controller/JobOfferController.java
+++ b/Back/src/main/java/ma/emsi/smartrhv1/controller/JobOfferController.java
@@ -4,6 +4,9 @@ import jakarta.validation.Valid;
 import ma.emsi.smartrhv1.model.JobOffer;
 import ma.emsi.smartrhv1.services.JobOfferService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,8 +22,11 @@ public class JobOfferController {
     private JobOfferService jobOfferService;
 
     @GetMapping
-    public ResponseEntity<List<JobOffer>> getAllJobOffers() {
-        return ResponseEntity.ok(jobOfferService.findAll());
+    public ResponseEntity<Page<JobOffer>> getAllJobOffers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, Math.min(size, 100));
+        return ResponseEntity.ok(jobOfferService.findAll(pageable));
     }
 
     @PostMapping


### PR DESCRIPTION
## Description\n\nAjout de la pagination sur l'endpoint `GET /api/job-offers` via `Pageable` Spring Data.\n\n## Changements\n\n- Paramètres `page` (défaut: 0) et `size` (défaut: 10, max: 100)\n- Réponse `Page<JobOffer>` avec métadonnées `totalElements`, `totalPages`\n\n## Checklist\n\n- [x] Le code compile sans erreur\n- [x] Rétrocompatible (paramètres optionnels)\n- [x] CHANGELOG.md mis à jour