### PR TITLE
[ADD] modèle RefreshToken pour rotation des tokens JWT

### DIFF
--- a/Back/src/main/java/ma/emsi/smartrhv1/model/RefreshToken.java
+++ b/Back/src/main/java/ma/emsi/smartrhv1/model/RefreshToken.java
@@ -1,0 +1,23 @@
+package ma.emsi.smartrhv1.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Data
+@Document(collection = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    private String id;
+
+    private String token;
+    private String username;
+    private Instant expiresAt;
+
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+}


### PR DESCRIPTION
## Description\n\nAjout du modèle `RefreshToken` pour implémenter la rotation des tokens JWT.\n\n## Changements\n\n- Modèle `RefreshToken` avec champs `token`, `username`, `expiresAt`\n- Méthode utilitaire `isExpired()`\n- Collection MongoDB `refresh_tokens`\n\n## Checklist\n\n- [x] Le code compile sans erreur\n- [x] Tests à ajouter dans la prochaine itération