### PR TITLE
[FIX] configuration CORS centralisée avec ALLOWED_ORIGINS

### DIFF
--- a/Back/src/main/java/ma/emsi/smartrhv1/config/SecurityConfig.java
+++ b/Back/src/main/java/ma/emsi/smartrhv1/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package ma.emsi.smartrhv1.config;
 
 import ma.emsi.smartrhv1.security.JwtAuthFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -12,6 +13,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -20,15 +27,31 @@ public class SecurityConfig {
     @Autowired
     private JwtAuthFilter jwtAuthFilter;
 
+    @Value("${allowed.origins:http://localhost:3000}")
+    private String allowedOrigins;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()


### PR DESCRIPTION
## Description\n\nRemplacement du `@CrossOrigin(origins = \"*\")` par une configuration CORS centralisée dans `SecurityConfig`.\n\n## Changements\n\n- Bean `CorsConfigurationSource` configuré via variable `ALLOWED_ORIGINS`\n- Suppression du wildcard `*` en production\n- Valeur par défaut `http://localhost:3000` pour le développement\n\n## Checklist\n\n- [x] Le code compile sans erreur\n- [x] Variable ajoutée dans `.env.example`\n- [x] Sécurité renforcée en production