### PR TITLE
[ADD] Spring Boot Actuator health check

### DIFF
--- a/Back/src/main/resources/application.properties
+++ b/Back/src/main/resources/application.properties
@@ -1,3 +1,10 @@
 spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/smartrhv1}
 jwt.secret=${JWT_SECRET:SmartRH-JWT-Secret-Key-Change-In-Production-Min-256bits-00000}
 jwt.expiration=${JWT_EXPIRATION:86400000}
+
+# Actuator
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=when-authorized
+management.info.env.enabled=true
+info.app.name=SmartRH
+info.app.version=1.1.0


### PR DESCRIPTION
## Description\n\nActivation de Spring Boot Actuator avec exposition limitée aux endpoints `health` et `info`.\n\n## Changements\n\n- `GET /actuator/health` retourne le statut de l'application et de MongoDB\n- `GET /actuator/info` retourne le nom et la version de l'app\n- Détails visibles uniquement pour les utilisateurs authentifiés\n\n## Checklist\n\n- [x] Pas d'exposition de métriques sensibles\n- [x] Compatible avec les health checks Docker et load balancers